### PR TITLE
Use gradle:6.8-jdk11 as builder image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/jbake-dist
+/dist
+.gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine as builder
+FROM gradle:6.8-jdk11 as builder
 
 LABEL maintainer="https://jbake.org/community/team.html"
 
@@ -10,7 +10,7 @@ COPY . /usr/src/jbake
 RUN set -o errexit -o nounset \
     && echo "Building JBake" \
     && cd /usr/src/jbake \
-    && ./gradlew installDist \
+    && gradle --no-daemon installDist \
     && cp -r jbake-dist/build/install/jbake/* $JBAKE_HOME \
     && rm -r ~/.gradle /usr/src/jbake
 


### PR DESCRIPTION
Hi Jon,
You can use a gradle image instead of gradle wrapper. It's a little faster in ci. 
I also recommend to add a dockerignore to not copying all work directory in the docker context when building locally.

Jeremie